### PR TITLE
updated dojo_core -> dojo

### DIFF
--- a/Scarb.toml
+++ b/Scarb.toml
@@ -8,7 +8,7 @@ cairo-version = ">=2.0.0-rc0"
 sierra-replace-ids = true
 
 [dependencies]
-dojo_core = { git = "https://github.com/dojoengine/dojo", tag = "nightly-a319f1cf3fc8ab106c7147452a3b19b572b17f0d"}
+dojo = { git = "https://github.com/dojoengine/dojo", tag = "nightly-19293e5e065e14ecda25118b1e35a486de638fe4"}
 
 [[target.dojo]]
 

--- a/src/systems.cairo
+++ b/src/systems.cairo
@@ -75,10 +75,10 @@ mod tests {
     use core::traits::Into;
     use array::ArrayTrait;
 
-    use dojo_core::auth::systems::{Route, RouteTrait};
-    use dojo_core::interfaces::IWorldDispatcherTrait;
+    use dojo::auth::systems::{Route, RouteTrait};
+    use dojo::interfaces::IWorldDispatcherTrait;
 
-    use dojo_core::test_utils::spawn_test_world;
+    use dojo::test_utils::spawn_test_world;
 
     use dojo_examples::components::PositionComponent;
     use dojo_examples::components::MovesComponent;


### PR DESCRIPTION
As for the latest nightly release the repo has been updated to have `dojo`  rather than `dojo_core` as deps