### PR TITLE
Fix code spacing in `spawn` module

### DIFF
--- a/src/systems.cairo
+++ b/src/systems.cairo
@@ -15,7 +15,8 @@ mod spawn {
             (
                 Moves {
                     player: ctx.origin, remaining: 10
-                    }, Position {
+                },
+                Position {
                     player: ctx.origin, x: position.x + 10, y: position.y + 10
                 },
             )


### PR DESCRIPTION
Related to:
- https://github.com/dojoengine/book/pull/42

Seems to be a bug related to the Cairo linter because it's definitely more readable this way.