### PR TITLE
Update to v0.3.1

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -10,7 +10,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - run: curl -L https://install.dojoengine.org | bash
-    - run: /home/runner/.config/.dojo/bin/dojoup -v v0.3.0
+    - run: /home/runner/.config/.dojo/bin/dojoup -v v0.3.1
     - run: |
         /home/runner/.config/.dojo/bin/sozo build
         /home/runner/.config/.dojo/bin/sozo test

--- a/Scarb.toml
+++ b/Scarb.toml
@@ -1,13 +1,13 @@
 [package]
 cairo-version = "2.2.0"
 name = "dojo_examples"
-version = "0.3.0"
+version = "0.3.1"
 
 [cairo]
 sierra-replace-ids = true
 
 [dependencies]
-dojo = { git = "https://github.com/dojoengine/dojo", rev = "v0.3.0" }
+dojo = { git = "https://github.com/dojoengine/dojo", rev = "v0.3.1" }
 
 [[target.dojo]]
 

--- a/Scarb.toml
+++ b/Scarb.toml
@@ -7,7 +7,7 @@ version = "0.3.1"
 sierra-replace-ids = true
 
 [dependencies]
-dojo = { git = "https://github.com/dojoengine/dojo", rev = "v0.3.1" }
+dojo = { git = "https://github.com/dojoengine/dojo", version = "0.3.1" }
 
 [[target.dojo]]
 


### PR DESCRIPTION
This is a very simple submission but can significantly improve the experience for beginners.
The default version currently installed by dojoup is `0.3.1`, but currently `sozo init` will download the `dojo-starter` of `0.3.0`, which causes the following error when users run `sozo build`:

```
    Blocking waiting for file lock on package cache
    Updating git repository https://github.com/dojoengine/dojo
    Updating git repository https://github.com/dojoengine/dojo
   Compiling dojo_examples v0.3.1 (/mnt/d/code/dojo-chess-cn/Scarb.toml)
error: compiler plugin could not be loaded `dojo_plugin v0.3.0 (git+https://github.com/dojoengine/dojo?tag=v0.3.0)`
```

This PR updates `dojo-starter` so that users can directly perform `sozo build` and `sozo test` without encountering errors, which helps improve the development experience for beginners.