### PR TITLE
Update attribute notation

### DIFF
--- a/src/systems/actions.cairo
+++ b/src/systems/actions.cairo
@@ -40,7 +40,7 @@ mod actions {
 
 
     // impl: implement functions specified in trait
-    #[external(v0)]
+    #[abi(embed_v0)]
     impl ActionsImpl of IActions<ContractState> {
         // ContractState is defined by system decorator expansion
         fn spawn(self: @ContractState) {


### PR DESCRIPTION
Updated the `#[external(v0)]` attribute to `#[abi(embed_v0)]` as per [Cairo 2.3.0 update](https://community.starknet.io/t/cairo-v2-3-0-release-candidate/101137)

_We encourage devs to stop using the `#[external(v0)]` annotation, which may be deprecated in the future. Instead, use `#[abi(per_item)]` or `#[abi(embed_v0)]` ...._
