### PR TITLE
fix: dojo dependencies version to 0.5.1

### DIFF
--- a/Scarb.toml
+++ b/Scarb.toml
@@ -7,7 +7,7 @@ version = "0.5.0"
 sierra-replace-ids = true
 
 [dependencies]
-dojo = { git = "https://github.com/dojoengine/dojo", version = "0.5.0" }
+dojo = { git = "https://github.com/dojoengine/dojo", version = "0.5.1" }
 
 [[target.dojo]]
 


### PR DESCRIPTION
Currently, `dojoup` will install dojo 0.5.1, so `sozo build` will fail with version 0.5.0, upgrade to 0.5.1.