### PR TITLE
Fix Manifest file path in auth and spawn scripts

### DIFF
--- a/scripts/default_auth.sh
+++ b/scripts/default_auth.sh
@@ -16,8 +16,9 @@ echo "--------------------------------------------------------------------------
 
 # enable system -> models authorizations
 sozo auth grant --world $WORLD_ADDRESS --wait writer \
-  Position,$ACTIONS_ADDRESS \
-  Moves,$ACTIONS_ADDRESS \
-  > /dev/null
+ Position,$ACTIONS_ADDRESS \
+ Moves,$ACTIONS_ADDRESS \
+ > /dev/null
 
 echo "Default authorizations have been successfully set."
+

--- a/scripts/default_auth.sh
+++ b/scripts/default_auth.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 pushd $(dirname "$0")/..
 
-export RPC_URL="http://localhost:5050";
+export RPC_URL="http://localhost:5050"
 
 export WORLD_ADDRESS=$(cat ./manifests/deployments/KATANA.json | jq -r '.world.address')
 
@@ -16,9 +16,8 @@ echo "--------------------------------------------------------------------------
 
 # enable system -> models authorizations
 sozo auth grant --world $WORLD_ADDRESS --wait writer \
- Position,$ACTIONS_ADDRESS \
- Moves,$ACTIONS_ADDRESS \
- > /dev/null
+  Position,$ACTIONS_ADDRESS \
+  Moves,$ACTIONS_ADDRESS \
+  >/dev/null
 
 echo "Default authorizations have been successfully set."
-

--- a/scripts/default_auth.sh
+++ b/scripts/default_auth.sh
@@ -4,20 +4,20 @@ pushd $(dirname "$0")/..
 
 export RPC_URL="http://localhost:5050";
 
-export WORLD_ADDRESS=$(cat ./target/dev/manifest.json | jq -r '.world.address')
+export WORLD_ADDRESS=$(cat ./manifests/deployments/KATANA.json | jq -r '.world.address')
 
-export ACTIONS_ADDRESS=$(cat ./target/dev/manifest.json | jq -r '.contracts[] | select(.name == "dojo_starter::systems::actions::actions" ).address')
+export ACTIONS_ADDRESS=$(cat ./manifests/deployments/KATANA.json | jq -r '.contracts[] | select(.name == "dojo_starter::systems::actions::actions" ).address')
 
 echo "---------------------------------------------------------------------------"
-echo world : $WORLD_ADDRESS 
+echo world : $WORLD_ADDRESS
 echo " "
 echo actions : $ACTIONS_ADDRESS
 echo "---------------------------------------------------------------------------"
 
 # enable system -> models authorizations
 sozo auth grant --world $WORLD_ADDRESS --wait writer \
- Position,$ACTIONS_ADDRESS \
- Moves,$ACTIONS_ADDRESS \
- > /dev/null
+  Position,$ACTIONS_ADDRESS \
+  Moves,$ACTIONS_ADDRESS \
+  > /dev/null
 
 echo "Default authorizations have been successfully set."

--- a/scripts/spawn.sh
+++ b/scripts/spawn.sh
@@ -4,9 +4,9 @@ pushd $(dirname "$0")/..
 
 export RPC_URL="http://localhost:5050";
 
-export WORLD_ADDRESS=$(cat ./target/dev/manifest.json | jq -r '.world.address')
+export WORLD_ADDRESS=$(cat ./manifests/deployments/KATANA.json | jq -r '.world.address')
 
-export ACTIONS_ADDRESS=$(cat ./target/dev/manifest.json | jq -r '.contracts[] | select(.name == "dojo_starter::systems::actions::actions" ).address')
+export ACTIONS_ADDRESS=$(cat ./manifests/deployments/KATANA.json | jq -r '.contracts[] | select(.name == "dojo_starter::systems::actions::actions" ).address')
 
 # sozo execute --world <WORLD_ADDRESS> <CONTRACT> <ENTRYPOINT>
 sozo execute --world $WORLD_ADDRESS $ACTIONS_ADDRESS spawn --wait


### PR DESCRIPTION
**Changes Summary**

**default_auth** and **spawn** scripts fails because of incorrect file path. now manifest file gets generated at top-level manifest folder.
