### PR TITLE
fix: scripts sozo execute

### DIFF
--- a/scripts/move.sh
+++ b/scripts/move.sh
@@ -4,7 +4,7 @@ pushd $(dirname "$0")/..
 
 export RPC_URL="http://localhost:5050";
 
-export WORLD_ADDRESS=$(cat ./manifests/dev/manifest.json | jq -r '.world.address')
+export WORLD_ADDRESS=$(cat ./manifests/dev/deployment/manifest.json | jq -r '.world.address')
 
 # sozo execute --world <WORLD_ADDRESS> <CONTRACT> <ENTRYPOINT>
-sozo execute --world $WORLD_ADDRESS dojo_starter::systems::actions::actions move -c 1 --wait
+sozo execute --world $WORLD_ADDRESS dojo_starter::systems::actions::dojo_starter-actions move -c 1 --wait

--- a/scripts/spawn.sh
+++ b/scripts/spawn.sh
@@ -4,7 +4,7 @@ pushd $(dirname "$0")/..
 
 export RPC_URL="http://localhost:5050";
 
-export WORLD_ADDRESS=$(cat ./manifests/dev/manifest.json | jq -r '.world.address')
+export WORLD_ADDRESS=$(cat ./manifests/dev/deployment/manifest.json | jq -r '.world.address')
 
 # sozo execute --world <WORLD_ADDRESS> <CONTRACT> <ENTRYPOINT>
-sozo execute --world $WORLD_ADDRESS dojo_starter::systems::actions::actions spawn --wait
+sozo execute --world $WORLD_ADDRESS dojo_starter::systems::actions::dojo_starter-actions spawn --wait


### PR DESCRIPTION
When running ./scripts/move.sh or ./scripts/spawn.sh I got the following errors: 

<img width="1311" alt="Screenshot 2024-08-21 at 5 05 24 PM" src="https://github.com/user-attachments/assets/6c257724-e9d8-4aa2-b762-d4b08e1901ef">

<img width="843" alt="Screenshot 2024-08-21 at 5 06 33 PM" src="https://github.com/user-attachments/assets/7ccf81e7-bcf7-402b-ba77-4502f0ddc897">

<img width="1333" alt="Screenshot 2024-08-21 at 5 06 42 PM" src="https://github.com/user-attachments/assets/0e420406-48f8-4d37-acd6-13766cf93b09">

Update the directory where the manifest is located. Also add the namespace to the `sozo execute` command.