### PR TITLE
Fix missing sozo build on compose.yaml

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -31,7 +31,7 @@ services:
       [
         "/bin/sh",
         "-c",
-        "cd /app && /root/.dojo/bin/sozo migrate --rpc-url http://katana:5050",
+        "cd /app && /root/.dojo/bin/sozo build && /root/.dojo/bin/sozo migrate --rpc-url http://katana:5050",
       ]
     restart: on-failure
 


### PR DESCRIPTION
This PR reference the issue #107

The `compose.yaml` file is missing the command `sozo build `so when executing `docker compose up` the application face the following issue:

![Screenshot_2025-06-26_13-32-00](https://github.com/user-attachments/assets/dcfcbfe4-871e-4371-8353-c72d743772da)

How to replicate the error:
* run `docker compose up` in the main branch

This PR adds the command `sozo build` to the `compose.yaml` making the docker container works. 